### PR TITLE
Update userparameter_systemd_services.conf

### DIFF
--- a/userparameter_systemd_services.conf
+++ b/userparameter_systemd_services.conf
@@ -1,4 +1,4 @@
-UserParameter=systemd.service.discovery,service_list=$(systemctl list-unit-files | grep service | grep enabled | awk '{print $1}' | sed -e 's/.service//' | grep -Ev 'getty|autovt');echo -n '{"data":[';for s in ${service_list}; do echo -n "{\"{#SERVICE}\": \"$s\"},";done | sed -e 's:\},$:\}:';echo -n ']}'
+UserParameter=systemd.service.discovery,service_list=$(systemctl list-unit-files | grep service | grep enabled | awk '{print $1}' | sed -e 's/\.service//' | grep -Ev 'getty|autovt');echo -n '{"data":[';for s in ${service_list}; do echo -n "{\"{#SERVICE}\": \"$s\"},";done | sed -e 's:\},$:\}:';echo -n ']}'
 
 UserParameter=systemd.service.status[*],$(systemctl status $1 2>/dev/null | grep -Ei 'running|active \(exited\)|active \(running\)' > /dev/null) && echo 0 || echo 1
 


### PR DESCRIPTION
Service discovery SED for search and replace of ".service" syntax didn't target only ".service", _service is also targeted and incorrectly reports on a service called mail_directory_service. E.G

~ # systemctl list-unit-files | grep service | grep enabled | awk '{print $1}'| sed 's/.service//' | grep mail_dir
mail_directory.service
~ # systemctl list-unit-files | grep service | grep enabled | awk '{print $1}'| sed 's/\.service//' | grep mail_dir
mail_directory_service