### PR TITLE
Add a check that the server hasn't just been restarted

### DIFF
--- a/usr/local/bin/zbx_service_restart_check.sh
+++ b/usr/local/bin/zbx_service_restart_check.sh
@@ -1,35 +1,15 @@
 #!/bin/bash
 
-service=$1
+service="$1"
+now=$(date +%s)
 
-date_compare() {
-  system_date=$(date +%F | tr -d -)
-  service_date=$(systemctl show "$service" --property=ActiveEnterTimestamp | awk '{print $2}' | tr -d -)
+# Don't alert if the server has just been restarted
+uptime=$(date +%s -d "$(uptime --since)")
+if [[ $(( $now - $uptime)) -lt 180 ]]; then
+        echo 0
+else
+        service_start=$(systemctl show "$service" --property=ActiveEnterTimestamp | awk -F= '{print $2}')
+        service_start_as_epoch=$(date -d "$service_start" +%s)
 
-  if [ "$system_date" -gt "$service_date" ]
-    then
-      echo 0
-    else
-      echo 1
-  fi
-}
-
-time_compare() {
-  system_time=$(date | awk '{print$4}' | tr -d :| sed 's/^0*//')
-  service_time=$(systemctl show "$service" --property=ActiveEnterTimestamp | awk '{print $3}' | tr -d : | sed 's/^0*//')
-  diff=$(( ${system_time#0} - ${service_time#0} ))
-
-  if [ $diff -lt 180 ]
-    then
-      echo 1
-    else
-      echo 0
-  fi
-}
-
-if [ "$(date_compare)" == 1 ]
-  then
-    time_compare
-  else
-    echo 0
+        [[ $(( $now - $service_start_as_epoch )) -lt 180 ]] && echo 1 || echo 0
 fi


### PR DESCRIPTION
I was finding that a lot of services were alerting on a server restart, so this patch checks to see if the server has been restarted and not flag if it has.

The coding style has changed to make zbx_service_restart_check.sh a little shorter.