### PR TITLE
Fix restarted service message typo

### DIFF
--- a/Template_App_systemd_Services.xml
+++ b/Template_App_systemd_Services.xml
@@ -182,7 +182,7 @@
                             <expression>{SystemD service monitoring template:systemd.service.restart[{#SERVICE}].last()}&lt;&gt;0</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
-                            <name>{#SERVICE} service has restart</name>
+                            <name>{#SERVICE} service has restarted</name>
                             <correlation_mode>0</correlation_mode>
                             <correlation_tag/>
                             <url/>


### PR DESCRIPTION
When a service has been restarted the template should print "service has restarted" instead of "service has restart"