### PR TITLE
systemctl improvements

### DIFF
--- a/Template_App_systemd_Services.xml
+++ b/Template_App_systemd_Services.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
-    <version>4.0</version>
-    <date>2019-02-23T23:06:43Z</date>
+    <version>5.0</version>
+    <date>2021-02-18T21:01:32Z</date>
     <groups>
         <group>
             <name>Templates/Applications</name>
@@ -9,8 +9,8 @@
     </groups>
     <templates>
         <template>
-            <template>SystemD service monitoring template</template>
-            <name>SystemD service monitoring template</name>
+            <template>Template systemd service monitoring</template>
+            <name>Template systemd service monitoring</name>
             <description>Discovery enabled systemd services, checks status every 1m, and checks systemd service active time to determine if service has restarted.</description>
             <groups>
                 <group>
@@ -22,221 +22,94 @@
                     <name>systemd</name>
                 </application>
             </applications>
-            <items/>
             <discovery_rules>
                 <discovery_rule>
                     <name>Service Discovery</name>
-                    <type>0</type>
-                    <snmp_community/>
-                    <snmp_oid/>
+                    <type>ZABBIX_ACTIVE</type>
                     <key>systemd.service.discovery</key>
                     <delay>5m</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
                     <lifetime>1d</lifetime>
-                    <description/>
                     <item_prototypes>
                         <item_prototype>
                             <name>{#SERVICE} Restart</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
+                            <type>ZABBIX_ACTIVE</type>
                             <key>systemd.service.restart[{#SERVICE}]</key>
-                            <delay>1m</delay>
                             <history>1d</history>
                             <trends>1d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
+                            <description>Checks to see if the service has restarted recently</description>
                             <applications>
                                 <application>
                                     <name>systemd</name>
                                 </application>
                             </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>0</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
+                            <valuemap>
+                                <name>Restart status</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}=1</expression>
+                                    <name>{#SERVICE} service has restarted</name>
+                                    <priority>WARNING</priority>
+                                    <description>Triggers an alert if a service has restarted</description>
+                                    <manual_close>YES</manual_close>
+                                </trigger_prototype>
+                            </trigger_prototypes>
                         </item_prototype>
                         <item_prototype>
                             <name>{#SERVICE} Status</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <snmp_oid/>
+                            <type>ZABBIX_ACTIVE</type>
                             <key>systemd.service.status[{#SERVICE}]</key>
-                            <delay>1m</delay>
                             <history>1d</history>
                             <trends>1d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Returns the status of the</description>
-                            <inventory_link>0</inventory_link>
+                            <description>Returns the status of the systemd service</description>
                             <applications>
                                 <application>
                                     <name>systemd</name>
                                 </application>
                             </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>0</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
+                            <valuemap>
+                                <name>Service state</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}=0</expression>
+                                    <name>{#SERVICE} service not running</name>
+                                    <priority>HIGH</priority>
+                                    <manual_close>YES</manual_close>
+                                </trigger_prototype>
+                            </trigger_prototypes>
                         </item_prototype>
                     </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{SystemD service monitoring template:systemd.service.restart[{#SERVICE}].last()}&lt;&gt;0</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{#SERVICE} service has restarted</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>2</priority>
-                            <description>Triggers an alert if a service has restarted</description>
-                            <type>0</type>
-                            <manual_close>1</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{SystemD service monitoring template:systemd.service.status[{#SERVICE}].last()}&lt;&gt;0</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{#SERVICE} service not running</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>1</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>0</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
                 </discovery_rule>
             </discovery_rules>
-            <httptests/>
-            <macros/>
-            <templates/>
-            <screens/>
         </template>
     </templates>
+    <value_maps>
+        <value_map>
+            <name>Restart status</name>
+            <mappings>
+                <mapping>
+                    <value>0</value>
+                    <newvalue>stable</newvalue>
+                </mapping>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>restarted</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>Service state</name>
+            <mappings>
+                <mapping>
+                    <value>0</value>
+                    <newvalue>Down</newvalue>
+                </mapping>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>Up</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+    </value_maps>
 </zabbix_export>

--- a/service_discovery_blacklist
+++ b/service_discovery_blacklist
@@ -1,1 +1,1 @@
-getty|autovt
+@|getty|autovt

--- a/userparameter_systemd_services.conf
+++ b/userparameter_systemd_services.conf
@@ -1,5 +1,5 @@
 UserParameter=systemd.service.discovery,/usr/local/bin/zbx_service_discovery.sh
 
-UserParameter=systemd.service.status[*],$(systemctl status --lines=0 $1 2>/dev/null | grep -Ei 'running|active \(exited\)|active \(running\)' > /dev/null) && echo 0 || echo 1
+UserParameter=systemd.service.status[*],$(systemctl is-active -q $1) && echo 1 || echo 0
 
 UserParameter=systemd.service.restart[*],/usr/local/bin/zbx_service_restart_check.sh $1

--- a/usr/local/bin/zbx_service_discovery.sh
+++ b/usr/local/bin/zbx_service_discovery.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-service_list=$(systemctl list-unit-files | grep -E '\.service\s+(generated|enabled)' | awk -F'.service ' '{print $1}')
+service_list=$(systemctl list-units -t service --no-pager --no-legend | awk -F'.service ' '{print $1}')
 
 [[ -r /etc/zabbix/service_discovery_whitelist ]] && {
     service_list=$(echo "$service_list" | grep -E -f /etc/zabbix/service_discovery_whitelist)

--- a/usr/local/bin/zbx_service_restart_check.sh
+++ b/usr/local/bin/zbx_service_restart_check.sh
@@ -4,12 +4,11 @@ service="$1"
 now=$(date +%s)
 
 # Don't alert if the server has just been restarted
-uptime=$(date +%s -d "$(uptime --since)")
-if [[ $(( $now - $uptime)) -lt 180 ]]; then
-        echo 0
+uptime=$(date +%s -d "$(systemctl show --value -p ActiveEnterTimestamp sysinit.target)")
+if [[ $(( now - uptime)) -lt 180 ]]; then
+  echo 0
 else
-        service_start=$(systemctl show "$service" --property=ActiveEnterTimestamp | awk -F= '{print $2}')
-        service_start_as_epoch=$(date -d "$service_start" +%s)
-
-        [[ $(( $now - $service_start_as_epoch )) -lt 180 ]] && echo 1 || echo 0
+  service_start=$(systemctl show --value -p ActiveEnterTimestamp "$service")
+  service_start_as_epoch=$(date -d "$service_start" +%s)
+  [[ $(( now - service_start_as_epoch )) -lt 180 ]] && echo 1 || echo 0
 fi

--- a/usr/local/bin/zbx_service_restart_check.sh
+++ b/usr/local/bin/zbx_service_restart_check.sh
@@ -6,9 +6,10 @@ now=$(date +%s)
 # Don't alert if the server has just been restarted
 uptime=$(date +%s -d "$(systemctl show --value -p ActiveEnterTimestamp sysinit.target)")
 if [[ $(( now - uptime)) -lt 180 ]]; then
-  echo 0
+        echo 0
 else
-  service_start=$(systemctl show --value -p ActiveEnterTimestamp "$service")
-  service_start_as_epoch=$(date -d "$service_start" +%s)
-  [[ $(( now - service_start_as_epoch )) -lt 180 ]] && echo 1 || echo 0
+        service_start=$(systemctl show --value -p ActiveEnterTimestamp "$service")
+        service_start_as_epoch=$(date -d "$service_start" +%s)
+
+        [[ $(( now - service_start_as_epoch )) -lt 180 ]] && echo 1 || echo 0
 fi


### PR DESCRIPTION
- `uptime --since` doesn't work on all systems which was the initial reason for this change. 
- Added some small script improvements of bash and systemctl calls
- update template and return values to match standard service value map